### PR TITLE
feat: sentry releases

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -17,9 +17,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: supabase/setup-cli@v1
         with:
           version: 2.24.3
+
+      - name: "Sentry - Create release"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: |
+          npx @sentry/cli releases new ${{ github.sha }}
+          npx @sentry/cli releases set-commits ${{ github.sha }} --auto
+          npx @sentry/cli releases deploys ${{ github.sha }} new -e production
 
       - name: "Supabase - Remote Connect"
         env:
@@ -30,4 +42,12 @@ jobs:
         run: |
           supabase link --project-ref $PROJECT_ID
           supabase db push
+          supabase secrets set SENTRY_RELEASE=${{ github.sha }}
           supabase functions deploy --use-api
+
+      - name: "Sentry - Finalize release"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: npx @sentry/cli releases finalize ${{ github.sha }}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -32,6 +32,11 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ vars.VITE_SUPABASE_ANON_KEY }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_RELEASE: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: |
           cd src/web
           deno run compile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,7 @@ Required in `.env` or Supabase secrets:
 - Deno formatting: 2-space indent, double quotes, semicolons
 - Run `deno task format` before committing
 - Run `deno task lint` to check for issues
+
+## Git
+
+When creating new files, always stage them with `git add <file>` after creating them.

--- a/src/web/deno.json
+++ b/src/web/deno.json
@@ -36,6 +36,8 @@
     "react-loading-indicators": "npm:react-loading-indicators@^1.0.0",
     "use-sound": "npm:use-sound@^5.0.0",
     "usehooks-ts": "npm:usehooks-ts@^3.1.1",
-    "vite": "npm:vite@^7.3.1"
+    "vite": "npm:vite@^7.3.1",
+    "@sentry/react": "npm:@sentry/react@^9.0.0",
+    "@sentry/vite-plugin": "npm:@sentry/vite-plugin@^3.0.0"
   }
 }

--- a/src/web/deno.json
+++ b/src/web/deno.json
@@ -37,7 +37,7 @@
     "use-sound": "npm:use-sound@^5.0.0",
     "usehooks-ts": "npm:usehooks-ts@^3.1.1",
     "vite": "npm:vite@^7.3.1",
-    "@sentry/react": "npm:@sentry/react@^9.0.0",
-    "@sentry/vite-plugin": "npm:@sentry/vite-plugin@^3.0.0"
+    "@sentry/react": "npm:@sentry/react@^10.43.0",
+    "@sentry/vite-plugin": "npm:@sentry/vite-plugin@^5.1.1"
   }
 }

--- a/src/web/src/lib/sentry.ts
+++ b/src/web/src/lib/sentry.ts
@@ -1,0 +1,14 @@
+import * as Sentry from "@sentry/react";
+
+export function initSentry() {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) return;
+
+  Sentry.init({
+    dsn,
+    release: import.meta.env.VITE_RELEASE,
+    environment: import.meta.env.MODE,
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 1.0,
+  });
+}

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -3,6 +3,9 @@ import { StrictMode } from "react";
 // @deno-types="@types/react-dom/client"
 import { createRoot } from "react-dom/client";
 import App from "./app.tsx";
+import { initSentry } from "./lib/sentry.ts";
+
+initSentry();
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,7 +1,9 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import deno from "@deno/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { lingui } from "@lingui/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -13,7 +15,23 @@ export default defineConfig({
       },
     }),
     lingui(),
+    sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      release: {
+        name: process.env.VITE_RELEASE,
+        setCommits: { auto: true },
+        deploy: { env: process.env.NODE_ENV ?? "production" },
+      },
+      sourcemaps: {
+        filesToDeleteAfterUpload: ["dist/**/*.map"],
+      },
+    }),
   ],
+  build: {
+    sourcemap: true,
+  },
   optimizeDeps: {
     include: ["@tanstack/react-query"],
   },

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -19,6 +19,8 @@ export class SentryErrorHandler {
     Sentry.init({
       dsn: Deno.env.get("SENTRY_DSN")!,
       defaultIntegrations: false,
+      release: Deno.env.get("SENTRY_RELEASE"),
+      environment: "production",
       tracesSampleRate: 1.0,
       // deno-lint-ignore ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
Next steps:

  1. Get your DSN — Sentry project → Settings → Client Keys → copy the DSN                                                                                                                                                   
  2. Create an Auth Token — Sentry → Settings → Auth Tokens → create token with scopes: project:releases, org:read
  3. Note your org slug and project slug — visible in Sentry URLs: sentry.io/organizations/<org>/projects/<project>/                                                                                                         
                                                                                                                                                                                                                             
  ### GitHub — Secrets                                                                                                                                                                                                           
                                                                                                                                                                                                                             
  Settings → Secrets and variables → Actions → Secrets:                                                                                                                                                                      
  - SENTRY_AUTH_TOKEN — the token from step 2 above         
                                                                                                                                                                                                                             
  ### GitHub — Variables
                                                                                                                                                                                                                             
  Settings → Secrets and variables → Actions → Variables:   
  - SENTRY_ORG — your org slug
  - SENTRY_PROJECT — your project slug                                                                                                                                                                                       
  - VITE_SENTRY_DSN — the DSN from step 1
                                                                                                                                                                                                                             
  ### Local .env                                                
                                                                                                                                                                                                                             
  Fill in the blank you currently have:
  VITE_SENTRY_DSN=https://xxxx@xxxx.ingest.sentry.io/xxxx                                                                                                                                                                    
                                                                                                                                                                                                                             
  Supabase — Secrets (one-time manual set)                                                                                                                                                                                   
                                                                                                                                                                                                                             
  The deploy workflow will keep SENTRY_RELEASE up to date automatically going forward, but you may also want to set SENTRY_DSN as a Supabase secret if it isn't already:                                                     
  supabase secrets set SENTRY_DSN=https://xxxx@xxxx.ingest.sentry.io/xxxx                                                                                                                                                    
                                                                                                                                                                                                                             
  ---                                                                                                                                                                                                                        
  Once those are in place, the next push to dev will create releases in Sentry for both the web app and Edge Functions automatically.                                                                                        
                                                                                                                                                             